### PR TITLE
feat: implement Statuses API endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,34 @@ When implementing new Motion API endpoints:
 ## Development Best Practices
 
 - Commit often using conventional commits. Use feature branches.
+
+## Feature Development Workflow
+
+When implementing new features from GitHub issues:
+
+1. **Planning & Setup**:
+   - Use TodoWrite to create a task list based on the issue requirements
+   - Create a feature branch: `git checkout -b feat/feature-name`
+
+2. **Implementation Steps** (following the established patterns):
+   - Add type definitions in `src/types.ts`
+   - Add method to `MotionClient` class in `src/motion-client.ts`
+   - Create tool file in `src/tools/`
+   - Register tool in `src/tools/index.ts`
+   - Update TodoWrite to mark tasks as completed
+
+3. **Quality Assurance**:
+   - Run `npm run build` to ensure no TypeScript errors
+   - Verify all imports and exports are correctly wired
+
+4. **Git Workflow**:
+   - Stage changes: `git add .`
+   - Commit with descriptive message referencing the issue
+   - Push feature branch: `git push -u origin feat/feature-name`
+   - Create PR that references and closes the issue
+   - Ensure PR description is clean (avoid shell command artifacts)
+
+5. **Documentation**:
+   - Use Playwright for fetching API documentation when WebFetch is not preferred
+   - Follow existing code patterns and naming conventions
+   - Include proper error handling in all tools

--- a/src/motion-client.ts
+++ b/src/motion-client.ts
@@ -14,7 +14,8 @@ import {
   CreateProjectRequest,
   CreateProjectResponse,
   GetProjectResponse,
-  MotionSchedulesResponse
+  MotionSchedulesResponse,
+  MotionStatusesResponse
 } from "./types.js";
 
 const MOTION_API_BASE_URL = "https://api.usemotion.com/v1";
@@ -211,6 +212,14 @@ export class MotionClient {
 
   async getSchedules(): Promise<MotionSchedulesResponse> {
     const endpoint = "/schedules";
+    return this.makeRequest(endpoint);
+  }
+
+  async getStatuses(workspaceId: string): Promise<MotionStatusesResponse> {
+    const queryParams = new URLSearchParams();
+    queryParams.append("workspaceId", workspaceId);
+    
+    const endpoint = `/statuses?${queryParams.toString()}`;
     return this.makeRequest(endpoint);
   }
 }

--- a/src/tools/get-statuses.ts
+++ b/src/tools/get-statuses.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import type { ToolRegistrar } from "./types.js";
+
+export const registerGetStatusesTool: ToolRegistrar = (server, client) => {
+  server.tool(
+    "get_motion_statuses",
+    {
+      workspaceId: z.string().describe("The workspace ID to get statuses for"),
+    },
+    async (params) => {
+      try {
+        const result = await client.getStatuses(params.workspaceId);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,6 +14,7 @@ import { registerListProjectsTool } from "./list-projects.js";
 import { registerGetProjectTool } from "./get-project.js";
 import { registerCreateProjectTool } from "./create-project.js";
 import { registerGetSchedulesTool } from "./get-schedules.js";
+import { registerGetStatusesTool } from "./get-statuses.js";
 
 export function registerAllTools(server: McpServer, client: MotionClient) {
   registerListTasksTool(server, client);
@@ -30,4 +31,5 @@ export function registerAllTools(server: McpServer, client: MotionClient) {
   registerGetProjectTool(server, client);
   registerCreateProjectTool(server, client);
   registerGetSchedulesTool(server, client);
+  registerGetStatusesTool(server, client);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,3 +207,11 @@ export interface MotionSchedule {
 }
 
 export type MotionSchedulesResponse = MotionSchedule[];
+
+export interface MotionStatus {
+  name: string;
+  isDefaultStatus: boolean;
+  isResolvedStatus: boolean;
+}
+
+export type MotionStatusesResponse = MotionStatus[];


### PR DESCRIPTION
## Summary
- Implement Motion's `/v1/statuses` API endpoint
- Add `get_motion_statuses` tool to retrieve workspace statuses

## Changes
- Add `MotionStatus` and `MotionStatusesResponse` type definitions
- Add `getStatuses` method to MotionClient class  
- Create `get_motion_statuses` tool with workspaceId parameter
- Register tool in tools index

## Test plan
- [x] Build succeeds without errors
- [x] Types are properly defined
- [x] Tool is registered and available

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)